### PR TITLE
fix add_torrent, adding missing param

### DIFF
--- a/aioaria2/client.py
+++ b/aioaria2/client.py
@@ -153,8 +153,9 @@ class _Aria2BaseClient:
         {"result":"2089b05ecca3d829"}
         """
         params = [torrent]
-        if uris:
-            params.append(uris)  # type: ignore
+        if not uris:
+            uris = []
+        params.append(uris)  # type: ignore
         params = add_options_and_position(params, options, position)
         return await self.jsonrpc("addTorrent", params)
 


### PR DESCRIPTION
fix #28

## Summary by Sourcery

Bug Fixes:
- Fixed handling of missing "uris" parameter in the `addTorrent` method to resolve issue #28.